### PR TITLE
Add basic Pytest suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ A aplicação utiliza Firebase Authentication para gerenciar usuários e protege
 
 Para executar testes:
 ```bash
+pip install pytest
 pytest tests/
 ```
 

--- a/tests/test_currency_utils.py
+++ b/tests/test_currency_utils.py
@@ -1,0 +1,18 @@
+import pytest
+from utils.currency_utils import format_currency
+
+
+def test_format_currency_brl_default():
+    assert format_currency(1234.56, "BRL") == "R$ 1.234,56"
+
+
+def test_format_currency_usd():
+    assert format_currency(1234.56, "USD") == "$ 1,234.56"
+
+
+def test_format_currency_eur():
+    assert format_currency(1234.56, "EUR") == "€ 1.234,56"
+
+
+def test_format_currency_generic_no_symbol():
+    assert format_currency(1234.56, "GBP", show_symbol=False) == "1,234.56"

--- a/tests/test_date_utils.py
+++ b/tests/test_date_utils.py
@@ -1,0 +1,25 @@
+import datetime
+from utils import date_utils
+
+
+def test_get_date_range_today(monkeypatch):
+    fake_today = datetime.date(2024, 4, 10)
+    monkeypatch.setattr(date_utils, "get_today", lambda: fake_today)
+    start, end = date_utils.get_date_range("today")
+    assert start == fake_today and end == fake_today
+
+
+def test_get_date_range_this_week(monkeypatch):
+    fake_today = datetime.date(2024, 4, 10)  # Wednesday
+    monkeypatch.setattr(date_utils, "get_today", lambda: fake_today)
+    start, end = date_utils.get_date_range("this_week")
+    assert start == datetime.date(2024, 4, 8)
+    assert end == datetime.date(2024, 4, 14)
+
+
+def test_get_date_range_last_30_days(monkeypatch):
+    fake_today = datetime.date(2024, 4, 10)
+    monkeypatch.setattr(date_utils, "get_today", lambda: fake_today)
+    start, end = date_utils.get_date_range("last_30_days")
+    assert start == datetime.date(2024, 3, 12)
+    assert end == fake_today


### PR DESCRIPTION
## Summary
- create tests directory with Pytest test cases
- cover currency/date utility functions
- document how to run the tests in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684517d3e4cc832bac1991dbca365901